### PR TITLE
Create SlowQuerySummarizer

### DIFF
--- a/summarizer/app.rb
+++ b/summarizer/app.rb
@@ -2,12 +2,14 @@ require 'sinatra'
 require 'yaml'
 require './query_summarizer'
 require './access_summarizer'
+require './slow_query_summarizer'
 
 set :public_folder, File.dirname(__FILE__) + '/static'
 
 get '/' do
   @query_summary = QuerySummarizer.new(config['query_log']).summarize
   @access_summary = AccessSummarizer.new(config['access_log']).summarize
+  @slow_query_summary = SlowQuerySummarizer.new(config['slow_query_log']).summarize
   erb :index
 end
 

--- a/summarizer/app.rb
+++ b/summarizer/app.rb
@@ -18,7 +18,7 @@ def config
 end
 
 helpers do
-  def format(ms)
-    "#{(ms * 1000).round(2)}ms"
+  def format(s)
+    "#{(s * 1000).round(2)}ms"
   end
 end

--- a/summarizer/config.yml
+++ b/summarizer/config.yml
@@ -19,3 +19,5 @@ access_log:
 query_log:
   filepath: './query.log'
   root_dir: '/home/isucon/private_isu/webapp/ruby'
+slow_query_log:
+  filepath: './slow_query.log'

--- a/summarizer/slow_query.log
+++ b/summarizer/slow_query.log
@@ -1,0 +1,114 @@
+Count: 2262  Time=0.01s (16s)  Lock=0.00s (0s)  Rows=0.7 (1630), root[root]@localhost
+  SELECT * FROM `comments` WHERE `post_id` = N ORDER BY `created_at` DESC LIMIT N
+
+Count: 495  Time=0.03s (14s)  Lock=0.00s (0s)  Rows=0.6 (274), root[root]@localhost
+  SELECT * FROM `posts` WHERE `id` = N
+
+Count: 2294  Time=0.01s (12s)  Lock=0.00s (0s)  Rows=0.3 (662), root[root]@localhost
+  SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = N
+
+Count: 11  Time=0.16s (1s)  Lock=0.01s (0s)  Rows=0.0 (0), root[root]@localhost
+  INSERT INTO `posts` (`user_id`, `mime`, `imgdata`, `body`) VALUES (N,'S','S','S')
+
+Count: 32  Time=0.04s (1s)  Lock=0.00s (0s)  Rows=1.0 (32), root[root]@localhost
+  SELECT * FROM `posts` WHERE `id` = 'S'
+
+Count: 32  Time=0.03s (0s)  Lock=0.00s (0s)  Rows=7.4 (236), root[root]@localhost
+  SELECT * FROM `comments` WHERE `post_id` = N ORDER BY `created_at` DESC
+
+Count: 17  Time=0.05s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), root[root]@localhost
+  INSERT INTO `users` (`account_name`, `passhash`) VALUES ('S','S')
+
+Count: 17  Time=0.05s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), root[root]@localhost
+  INSERT INTO `comments` (`post_id`, `user_id`, `comment`) VALUES ('S',N,'S')
+
+Count: 26821  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=469.5 (12591295), root[root]@localhost
+  #
+
+Count: 90  Time=0.01s (0s)  Lock=0.00s (0s)  Rows=1334.1 (120066), root[root]@localhost
+  SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC
+
+Count: 24  Time=0.02s (0s)  Lock=0.00s (0s)  Rows=1.0 (24), root[root]@localhost
+  SELECT COUNT(*) AS count FROM `comments` WHERE `user_id` = N
+
+Count: 8084  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.3 (2344), root[root]@localhost
+  SELECT * FROM `users` WHERE `id` = N
+
+Count: 4  Time=0.04s (0s)  Lock=0.00s (0s)  Rows=7486.2 (29945), root[root]@localhost
+  SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `created_at` <= 'S' ORDER BY `created_at` DESC
+
+Count: 7  Time=0.02s (0s)  Lock=0.00s (0s)  Rows=1.0 (7), root[root]@localhost
+  SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (N,N,N,N,N,N,N,N,N)
+
+Count: 1  Time=0.11s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), root[root]@localhost
+  DELETE FROM users WHERE id > N
+
+Count: 24  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=10.4 (250), root[root]@localhost
+  SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `user_id` = N ORDER BY `created_at` DESC
+
+Count: 4  Time=0.02s (0s)  Lock=0.00s (0s)  Rows=1.0 (4), root[root]@localhost
+  SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (N,N,N,N,N,N,N,N,N,N,N)
+
+Count: 24  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=10.4 (250), root[root]@localhost
+  SELECT `id` FROM `posts` WHERE `user_id` = N
+
+Count: 3  Time=0.02s (0s)  Lock=0.00s (0s)  Rows=1.0 (3), root[root]@localhost
+  SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (N,N,N,N,N,N,N,N,N,N,N,N)
+
+Count: 3  Time=0.02s (0s)  Lock=0.00s (0s)  Rows=1.0 (3), root[root]@localhost
+  SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (N,N,N,N,N,N,N,N)
+
+Count: 1  Time=0.03s (0s)  Lock=0.00s (0s)  Rows=1.0 (1), root[root]@localhost
+  SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (N,N,N,N,N,N,N,N,N,N,N,N,N,N,N)
+
+Count: 1  Time=0.03s (0s)  Lock=0.00s (0s)  Rows=1.0 (1), root[root]@localhost
+  SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (N,N,N,N,N,N,N,N,N,N,N,N,N)
+
+Count: 1  Time=0.03s (0s)  Lock=0.00s (0s)  Rows=1.0 (1), root[root]@localhost
+  SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N)
+
+Count: 1  Time=0.03s (0s)  Lock=0.00s (0s)  Rows=1.0 (1), root[root]@localhost
+  SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (N,N,N,N,N,N)
+
+Count: 1  Time=0.02s (0s)  Lock=0.00s (0s)  Rows=1.0 (1), root[root]@localhost
+  SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N)
+
+Count: 1  Time=0.01s (0s)  Lock=0.00s (0s)  Rows=1.0 (1), root[root]@localhost
+  SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (N,N,N,N,N,N,N,N,N,N)
+
+Count: 1  Time=0.01s (0s)  Lock=0.00s (0s)  Rows=1.0 (1), root[root]@localhost
+  SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (N,N,N,N)
+
+Count: 66  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=1.0 (63), root[root]@localhost
+  SELECT * FROM users WHERE account_name = 'S' AND del_flg = N
+
+Count: 1  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), root[root]@localhost
+  UPDATE users SET del_flg = N
+
+Count: 24  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=1.0 (24), root[root]@localhost
+  SELECT * FROM `users` WHERE `account_name` = 'S' AND `del_flg` = N
+
+Count: 1  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), root[root]@localhost
+  UPDATE users SET del_flg = N WHERE id % N = N
+
+Count: 1  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), root[root]@localhost
+  flush logs
+
+Count: 17  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), root[root]@localhost
+  SELECT N FROM users WHERE `account_name` = 'S'
+
+Count: 1  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), root[root]@localhost
+  DELETE FROM posts WHERE id > N
+
+Count: 1  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), root[root]@localhost
+  DELETE FROM comments WHERE id > N
+
+Count: 1  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), 0users@0hosts
+  administrator command: Quit
+
+Count: 13364  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), 0users@0hosts
+  administrator command: Close stmt
+
+Count: 13456  Time=0.00s (0s)  Lock=0.00s (0s)  Rows=0.0 (0), 0users@0hosts
+  administrator command: Prepare
+

--- a/summarizer/slow_query_summarizer.rb
+++ b/summarizer/slow_query_summarizer.rb
@@ -10,6 +10,7 @@ class SlowQuerySummarizer
   end
 
   def summarize
+    return [] unless File.exists?(@filepath)
     File.readlines(@filepath)
       .slice_before { |line| line.start_with?("Count:") }
       .map { |lines|

--- a/summarizer/slow_query_summarizer.rb
+++ b/summarizer/slow_query_summarizer.rb
@@ -1,0 +1,37 @@
+class SlowQuerySummarizer
+
+  COUNT_REGEXP = /Count: (\d+)/
+  TIME_REGEXP = /Time=([\d|\.]+)s \((\d+)s\)/
+  LOCK_REGEXP = /Lock=([\d|\.]+)s \((\d+)s\)/
+  ROWS_REGEXP = /Rows=([\d|\.]+) \((\d+)\)/
+
+  def initialize(config)
+    @filepath = config['filepath']
+  end
+
+  def summarize
+    File.readlines(@filepath)
+      .slice_before { |line| line.start_with?("Count:") }
+      .map { |lines|
+        result = analyze_line(lines.first)
+        result[:sql] = lines[1..-1].join(" ").strip
+        result
+      }
+  end
+
+  private
+
+  def analyze_line(line)
+    return {} unless line
+    result = {}
+    result[:count] = line.match(COUNT_REGEXP)[1].to_i
+    result[:average] = line.match(TIME_REGEXP)[1].to_f
+    result[:sum] = line.match(TIME_REGEXP)[2].to_f
+    result[:lock_average] = line.match(LOCK_REGEXP)[1].to_f
+    result[:lock_sum] = line.match(LOCK_REGEXP)[2].to_f
+    result[:rows_average] = line.match(ROWS_REGEXP)[1].to_f
+    result[:rows_sum] = line.match(ROWS_REGEXP)[2].to_i
+    result
+  end
+
+end

--- a/summarizer/views/index.erb
+++ b/summarizer/views/index.erb
@@ -61,6 +61,37 @@
 <% end %>
 </tbody>
 </table>
+
+<h1>Slow Query log summary</h1>
+<table class="tablesorter" hidden>
+<thead>
+<tr>
+<th>SQL</th>
+<th>sum</th>
+<th>count</th>
+<th>average</th>
+<th>lock sum</th>
+<th>lock average</th>
+<th>rows sum</th>
+<th>rows average</th>
+</tr>
+</thead>
+<tbody>
+<% @slow_query_summary.each do |summary| %>
+<tr>
+<td><%= summary[:sql] %></td>
+<td><%= format(summary[:sum]) %></td>
+<td><%= summary[:count] %></td>
+<td><%= format(summary[:average]) %></td>
+<td><%= format(summary[:lock_sum]) %></td>
+<td><%= format(summary[:lock_average]) %></td>
+<td><%= summary[:rows_sum] %></td>
+<td><%= summary[:rows_average] %></td>
+</tr>
+<% end %>
+</tbody>
+</table>
+
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.27.6/js/jquery.tablesorter.js"></script>
 <script>

--- a/summarizer/views/index.erb
+++ b/summarizer/views/index.erb
@@ -62,35 +62,37 @@
 </tbody>
 </table>
 
-<h1>Slow Query log summary</h1>
-<table class="tablesorter" hidden>
-<thead>
-<tr>
-<th>SQL</th>
-<th>sum</th>
-<th>count</th>
-<th>average</th>
-<th>lock sum</th>
-<th>lock average</th>
-<th>rows sum</th>
-<th>rows average</th>
-</tr>
-</thead>
-<tbody>
-<% @slow_query_summary.each do |summary| %>
-<tr>
-<td><%= summary[:sql] %></td>
-<td><%= format(summary[:sum]) %></td>
-<td><%= summary[:count] %></td>
-<td><%= format(summary[:average]) %></td>
-<td><%= format(summary[:lock_sum]) %></td>
-<td><%= format(summary[:lock_average]) %></td>
-<td><%= summary[:rows_sum] %></td>
-<td><%= summary[:rows_average] %></td>
-</tr>
-<% end %>
-</tbody>
-</table>
+<% unless @slow_query_summary.empty? %>
+  <h1>Slow Query log summary</h1>
+  <table class="tablesorter" hidden>
+  <thead>
+  <tr>
+  <th>SQL</th>
+  <th>sum</th>
+  <th>count</th>
+  <th>average</th>
+  <th>lock sum</th>
+  <th>lock average</th>
+  <th>rows sum</th>
+  <th>rows average</th>
+  </tr>
+  </thead>
+  <tbody>
+  <% @slow_query_summary.each do |summary| %>
+    <tr>
+    <td><%= summary[:sql] %></td>
+    <td><%= format(summary[:sum]) %></td>
+    <td><%= summary[:count] %></td>
+    <td><%= format(summary[:average]) %></td>
+    <td><%= format(summary[:lock_sum]) %></td>
+    <td><%= format(summary[:lock_average]) %></td>
+    <td><%= summary[:rows_sum] %></td>
+    <td><%= summary[:rows_average] %></td>
+    </tr>
+  <% end %>
+  </tbody>
+  </table>
+<% end %>>
 
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.27.6/js/jquery.tablesorter.js"></script>


### PR DESCRIPTION
mysqldumpslowの結果を表示するようにしました。
- デプロイ前にログ削除
- ベンチ実行
- ベンチ実行後にmysqldumpslow実行
- summarizerで見る

みたいな運用をイメージしてます。他のログと違ってリアルタイムじゃないですが、まぁしかたないのかなと...
## このPRでやったこと
- `SlowQuerySummarizer`の作成
- Viewの一番下に結果を表示
## スクリーンショット

<img width="1254" alt="2016-09-21 23 50 34" src="https://cloud.githubusercontent.com/assets/7043127/18716019/3a339d04-8056-11e6-9961-84680f19604b.png">

@hokaccha つくってみましたー！
